### PR TITLE
Added player assignment from server to clients.

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,7 +1,7 @@
 from game_client import Game
 
 def main():
-    g = Game(2)
+    g = Game(5050)
     g.run()
 
 if __name__ == '__main__':

--- a/game_server.py
+++ b/game_server.py
@@ -1,3 +1,4 @@
+import time
 from board import Board
 import threading
 import socket
@@ -18,6 +19,7 @@ class Game:
 
         self.lock = threading.Lock()
 
+        self.ready = False
         self.n_connections = 0
         self.connections = []
         self.n_players = n_players
@@ -27,13 +29,28 @@ class Game:
         PORT = 5050
         self.server.bind( (HOST, PORT) )
 
+    def assign_players( self ):
+        if( self.ready ): return 0
+
+        print("[PLAYERS CONNECTED] assigning players to its avatars")
+        for player_number in range( len( self.connections ) ):
+            assign_msg = str(player_number + 1) + "***"
+            self.connections[ player_number ].send( assign_msg.encode('utf-8') )
+
+        self.ready = True
+
     def handle_player( self, conn, addr ):
         print("[NEW CONNECTION]" + str(addr[0]) + ":" + str(addr[1]) + " connected")
 
         while( self.n_connections < self.n_players ):
             pass
 
+        self.lock.acquire()
+        self.assign_players()
+        self.lock.release()
+
         while( True ):
+            print("[LISTENING] waiting on user moves...")
             bytes_received = 0
             client_msg = ""
 


### PR DESCRIPTION
In this PR we
- Added a feature to let the server assign which player is P1, which one is P2 and so forth
- Also, we corrected a few logic issues in Game.waiting_window from the client-side. Now, getch is non-blocking and will let the client read packets even if no key was pressed from the player. In the end, a new screen will be displayed if all players connect to play.